### PR TITLE
Utilities for block highlighting

### DIFF
--- a/src/main/java/de/melanx/excavar/api/Excavador.java
+++ b/src/main/java/de/melanx/excavar/api/Excavador.java
@@ -21,10 +21,10 @@ import java.util.Set;
 
 public class Excavador {
 
-    private final BlockPos start;
-    private final Level level;
-    private final ServerPlayer player;
-    private final Direction side;
+    public final BlockPos start;
+    public final Level level;
+    public final ServerPlayer player;
+    public final Direction side;
     private final BlockState originalState;
     private final List<BlockPos> blocksToMine = Lists.newArrayList();
     private final boolean preventToolBreaking;
@@ -80,7 +80,7 @@ public class Excavador {
      * @param preventToolBreaking Whether the tool should be saved while mining
      */
     public Excavador(@Nonnull ResourceLocation shapeId, @Nonnull BlockPos start, @Nonnull Level level, @Nonnull ServerPlayer player, @Nonnull Direction side, @Nonnull BlockState originalState, boolean requiresCorrectTool, boolean preventToolBreaking) {
-        this.start = start;
+        this.start = start.immutable();
         this.level = level;
         this.player = player;
         this.side = side;
@@ -91,9 +91,10 @@ public class Excavador {
     }
 
     /**
-     * Searches for the {@link BlockPos}es to break
+     * Searches for the {@link BlockPos}es to break if not already searched.
      */
     public void findBlocks() {
+        if (!this.blocksToMine.isEmpty()) return;
         int limit = ConfigHandler.blockLimit.get();
         this.blocksToMine.add(this.start);
         Set<BlockPos> usedBlocks = Sets.newHashSet();

--- a/src/main/java/de/melanx/excavar/client/BlockHighlighter.java
+++ b/src/main/java/de/melanx/excavar/client/BlockHighlighter.java
@@ -1,0 +1,51 @@
+package de.melanx.excavar.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import de.melanx.excavar.api.Excavador;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlockHighlighter {
+    
+    private final Excavador excavador;
+    private VoxelShape shape;
+
+    public BlockHighlighter(Excavador excavador) {
+        this.excavador = excavador;
+    }
+    
+    private VoxelShape shape() {
+        if (this.shape == null) {
+            this.excavador.findBlocks();
+            List<VoxelShape> allShapes = new ArrayList<>();
+            for (BlockPos pos : this.excavador.getBlocksToMine()) {
+                VoxelShape blockShape = this.excavador.level.getBlockState(pos).getVisualShape(this.excavador.level, pos, CollisionContext.empty());
+                double dx = pos.getX() - this.excavador.start.getX();
+                double dy = pos.getY() - this.excavador.start.getY();
+                double dz = pos.getZ() - this.excavador.start.getZ();
+                allShapes.add(blockShape.move(dx, dy, dz));
+            }
+            this.shape = Shapes.or(Shapes.empty(), allShapes.toArray(new VoxelShape[]{})).optimize();
+        }
+        return this.shape;
+    }
+    
+    public void render(PoseStack poseStack) {
+        poseStack.pushPose();
+        Vec3 projection = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+        poseStack.translate(this.excavador.start.getX() - projection.x, this.excavador.start.getY() - projection.y, this.excavador.start.getZ() - projection.z);
+        
+        VertexConsumer vertex = null; // TODO get an outline buffer.
+        LevelRenderer.renderVoxelShape(poseStack, vertex, this.shape(), 0, 0, 0, 1, 1, 1, 1);
+        poseStack.popPose();
+    }
+}


### PR DESCRIPTION
Adds utilities to highlight the blocks from an `Excavador` instance. There are two things missing for it to be used which I'll leave to you:

1. The `Excavador` instance needs to persist longer. The client needs to be able to create `Excavador` instances to use the `BlockHighlighter` and store them for the whole time, the same block is hovered from the same direction.
2. There needs to be a way to obtain a `VertexConsumer` to render in the outline render target. See the `// TODO` comment. This is currently done in TravelAnchors and it may be merged into LibX. You could then either use LibX or take the code from TravelAnchors, copy it into your own mod and maintain it.